### PR TITLE
Added PermissionRequiredMixin

### DIFF
--- a/src/nac/subviews/armis.py
+++ b/src/nac/subviews/armis.py
@@ -16,11 +16,12 @@
 from django.views.generic import View
 from django.core.cache import cache
 from django.shortcuts import render
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from helper.armis import get_armis_sites, get_devices, get_tenant_url, get_boundaries, map_ids_to_names, get_single_device, get_vlan_blacklist
 
 
-class ArmisView(LoginRequiredMixin, View):
+class ArmisView(LoginRequiredMixin, PermissionRequiredMixin, View):
+    permission_required = "nac.view_device"
     template_name = "armis_import.html"
 
     def _get_context(self):  # sets the site-context for armis_import.html, uses cache to be less time consuming

--- a/src/nac/subviews/device_management.py
+++ b/src/nac/subviews/device_management.py
@@ -3,7 +3,7 @@ from django.views.generic.edit import UpdateView, CreateView
 from django.db.models import Q
 from django.urls import reverse_lazy
 from django.shortcuts import render, redirect
-from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin, AccessMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 import json
 from django.http import JsonResponse
 from django.template.loader import render_to_string
@@ -15,7 +15,8 @@ from ..forms import DeviceForm, DeviceSearchForm, DeviceHistoryForm
 from ..validation import normalize_mac
 
 
-class DeviceListView(LoginRequiredMixin, ListView):
+class DeviceListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
+    permission_required = "nac.view_device"
     model = Device
     template_name = "devices.html"
     context_object_name = "device_list"
@@ -62,7 +63,9 @@ class DeviceListView(LoginRequiredMixin, ListView):
         return context
 
 
-class DeviceDetailView(LoginRequiredMixin, DetailView):
+class DeviceDetailView(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
+    permission_required = "nac.view_device"
+
     model = Device
     template_name = "device_detail.html"
 
@@ -128,7 +131,7 @@ class DeviceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
 
 
 class DeviceCreateView(LoginRequiredMixin, PermissionRequiredMixin, CreateView):
-    permission_required = "nac.create_device"
+    permission_required = "nac.add_device"
 
     model = Device
     form_class = DeviceForm

--- a/src/nac/subviews/device_management.py
+++ b/src/nac/subviews/device_management.py
@@ -3,7 +3,7 @@ from django.views.generic.edit import UpdateView, CreateView
 from django.db.models import Q
 from django.urls import reverse_lazy
 from django.shortcuts import render, redirect
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin, AccessMixin
 import json
 from django.http import JsonResponse
 from django.template.loader import render_to_string
@@ -67,7 +67,9 @@ class DeviceDetailView(LoginRequiredMixin, DetailView):
     template_name = "device_detail.html"
 
 
-class DeviceUpdateView(LoginRequiredMixin, UpdateView):
+class DeviceUpdateView(LoginRequiredMixin, PermissionRequiredMixin, UpdateView):
+    permission_required = "nac.change_device"
+
     model = Device
     form_class = DeviceForm
     template_name = "device_edit.html"
@@ -112,7 +114,9 @@ class DeviceUpdateView(LoginRequiredMixin, UpdateView):
         return super().post(request, *args, **kwargs)
 
 
-class DeviceDeleteView(LoginRequiredMixin, DetailView):
+class DeviceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
+    permission_required = "nac.delete_device"
+
     model = Device
     template_name = "device_delete.html"
 
@@ -123,7 +127,9 @@ class DeviceDeleteView(LoginRequiredMixin, DetailView):
         return redirect(reverse_lazy("devices"))
 
 
-class DeviceCreateView(LoginRequiredMixin, CreateView):
+class DeviceCreateView(LoginRequiredMixin, PermissionRequiredMixin, CreateView):
+    permission_required = "nac.create_device"
+
     model = Device
     form_class = DeviceForm
     template_name = "device_new.html"

--- a/src/tests/test_views/test_device_page.py
+++ b/src/tests/test_views/test_device_page.py
@@ -1,5 +1,6 @@
 import pytest
 from nac.models import Device, AdministrationGroup, CustomUser
+from django.contrib.auth.models import Group, Permission
 from nac.subviews.device_management import DeviceListView
 from django.test import RequestFactory
 from django.urls import reverse_lazy
@@ -32,9 +33,14 @@ def test_device_search(query, result):
 
 @pytest.mark.django_db
 def test_result_rendering(client):
+    test_group = Group.objects.create(name='view')
+    perm_view = Permission.objects.get(codename='view_device')
+    test_group.permissions.add(perm_view)
+
     test_user = CustomUser.objects.create()
     test_user.set_password("test")
     test_user.administration_group.set([AdministrationGroup.objects.get(pk=1)])
+    test_user.groups.add(test_group)
     test_user.save()
 
     client.force_login(test_user)


### PR DESCRIPTION
New users are created with no permissions by default, permissions can be granted in the admin menu. Devices can now only be edited, created and deleted if the user has the according permissions.