### PR TITLE
118 wrong error messages in device form

### DIFF
--- a/src/nac/forms.py
+++ b/src/nac/forms.py
@@ -146,7 +146,6 @@ class DeviceForm(ModelForm):
                                ValidationError("This field cannot be empty while \"%(field_name)s\" is selected",
                                                params={"field_name": Device._meta.get_field(field).verbose_name}))
 
-
         # prefill asset_id if not set
         if not cleaned_data.get('asset_id') or cleaned_data.get('asset_id').startswith('FQDN') and cleaned_data.get('appl_NAC_Hostname') and cleaned_data.get('dns_domain'):
             cleaned_data['asset_id'] = f"FQDN_{cleaned_data.get('appl_NAC_Hostname')}.{cleaned_data.get('dns_domain')}"

--- a/src/nac/forms.py
+++ b/src/nac/forms.py
@@ -143,8 +143,10 @@ class DeviceForm(ModelForm):
         for field in dependencies:
             if cleaned_data.get(field) and not cleaned_data.get(dependencies[field]):
                 self.add_error(dependencies[field],
-                               ValidationError("This field cannot be empty while %(field)s is selected",
-                                               params={"field": field}))
+                               ValidationError("This field cannot be empty while \"%(field_name)s\" is selected",
+                                               params={"field_name": Device._meta.get_field(field).verbose_name}))
+
+
         # prefill asset_id if not set
         if not cleaned_data.get('asset_id') or cleaned_data.get('asset_id').startswith('FQDN') and cleaned_data.get('appl_NAC_Hostname') and cleaned_data.get('dns_domain'):
             cleaned_data['asset_id'] = f"FQDN_{cleaned_data.get('appl_NAC_Hostname')}.{cleaned_data.get('dns_domain')}"

--- a/src/templates/devices.html
+++ b/src/templates/devices.html
@@ -8,7 +8,7 @@
 	 <form id="search_form" action="{% url 'devices' %}" method="get">
 		 <div class="row">
 			 {% for field in search_form %}
-			 <div class="col-md-4 ">
+			 <div class="col-md-4">
 				{{ field | as_crispy_field }}
 			 </div>
 			 {% endfor %}


### PR DESCRIPTION
The error messages now use the verbose names of the fields.